### PR TITLE
Versions mismatch

### DIFF
--- a/JcaptchaGrailsPlugin.groovy
+++ b/JcaptchaGrailsPlugin.groovy
@@ -10,7 +10,7 @@ class JcaptchaGrailsPlugin {
 	def authorEmail = "ld@ldaley.com"
 	def documentation = "http://grails.org/plugin/jcaptcha"
 
-	def version = "1.1"
+	def version = "1.3"
 	def grailsVersion = "2.0 > *"
 
 	def license = "APACHE"


### PR DESCRIPTION
Published JCaptcha plugin has version 1.2.1 http://grails.org/plugin/jcaptcha but source code manifest declares smaller version 1.1 https://github.com/alkemist/grails-jcaptcha-plugin/blob/master/JcaptchaGrailsPlugin.groovy
